### PR TITLE
Change biweight to mean when biweight is NaN

### DIFF
--- a/uvot-mosaic/offset_mosaic.py
+++ b/uvot-mosaic/offset_mosaic.py
@@ -482,8 +482,17 @@ def calc_overlap_val(hdu_sk, hdu_ex, overlap_x, overlap_y, method='biweight'):
         # calculate biweight
         #biweight_noclip = biweight_location(np.array(grab_pix))
         biweight_clip = biweight_location(pix_clip.data[~pix_clip.mask])
+
+        # if a lot of the image is 0, and the biweight is therefore NaN,
+        # use the mean instead
+        if np.isnan(biweight_clip):
+            print('Biweight is NaN, using mean instead')
+            biweight_clip = np.mean(pix_clip.data[~pix_clip.mask])
+        
         
         val.append(biweight_clip)
+
+        
 
 
     


### PR DESCRIPTION
This is a fix for #13, in which images with lots of zeroes can have a median absolute deviation of 0, and therefore a biweight of NaN.  In that case, the mean is now used instead of the biweight.  This isn't a perfect solution, since the mean depends on how the sigma clipping is done, but it will be a very small number in any case.
