### PR TITLE
updates to scattered light code

### DIFF
--- a/uvot-mosaic/uvot_scattered_light.py
+++ b/uvot-mosaic/uvot_scattered_light.py
@@ -293,7 +293,7 @@ def run_manual(hdu_sk, hdu_sl, exp_param, flat_param):
     #vmin = biweight_location(hdu_sk_smooth.data[hdu_sk_smooth.data > 0]) \
     #       - biweight_midvariance(hdu_sk_smooth.data[hdu_sk_smooth.data > 0])
     filt = sigma_clip(hdu_sk_smooth.data[hdu_sk_smooth.data > 0], sigma=2, iters=3)
-    vmin = np.mean(filt.data[~filt.mask]) - 3*np.std(filt.data[~filt.mask])
+    vmin = np.mean(filt.data[~filt.mask]) - 2.5*np.std(filt.data[~filt.mask])
     vmax = np.percentile(hdu_sk_smooth.data[hdu_sk_smooth.data > 0], 99)
 
     # manually calculate log(image)

--- a/uvot-mosaic/uvot_scattered_light.py
+++ b/uvot-mosaic/uvot_scattered_light.py
@@ -75,7 +75,7 @@ def fix_sl(input_folders,
     for filt in filter_list:
 
         # get the images that have observations in that filter
-        obs_list = [im for im in filter_exist.keys() if filt in filter_exist[im]]
+        obs_list = [im for im in sorted(filter_exist.keys()) if filt in filter_exist[im]]
 
         # check that images exist
         if len(obs_list) == 0:

--- a/uvot-mosaic/uvot_scattered_light.py
+++ b/uvot-mosaic/uvot_scattered_light.py
@@ -235,7 +235,9 @@ def sl_manual(sk_image, sl_image, sl_file, fix_redo=False):
             # that time isn't in the table
             # -> do the calculations
             if tstart in sl_data['tstart'] and fix_redo == True:
-                print('starting manual corrections for extension '+str(i))
+                print('\nstarting manual corrections for extension '+str(i))
+                print('   larger exp_param -> more prominent circle')
+                print('   larger flat_param -> steeper radial gradient')
                 ind = np.where(tstart == sl_data['tstart'])[0][0]
                 exp_param, flat_param = run_manual(hdu_sk[i], hdu_sl[i], sl_data['exp_param'][ind],
                                                        sl_data['flat_param'][ind])
@@ -243,7 +245,9 @@ def sl_manual(sk_image, sl_image, sl_file, fix_redo=False):
                 sl_data['flat_param'][ind] = flat_param                
                 sl_data.write(sl_file, format='ascii', overwrite=True)
             elif tstart not in sl_data['tstart']:
-                print('starting manual corrections for extension '+str(i))
+                print('\nstarting manual corrections for extension '+str(i))
+                print('   larger exp_param -> more prominent circle')
+                print('   larger flat_param -> steeper radial gradient')
                 #exp_param, flat_param = run_manual(hdu_sk[i], hdu_sl[i], 1.5, 0.35)
                 exp_param, flat_param = run_manual(hdu_sk[i], hdu_sl[i], 1.2, 0.4)
                 sl_data.add_row([tstart, exp_param, flat_param])


### PR DESCRIPTION
Improves the display and interface for doing manual scattered light corrections:
* bug fix: during interactive part, corrections were being successively applied to the same image, rather than being applied from scratch
* calculates log scaling using ds9 formula, rather than aplpy "log" scale
* images appear in order of obsid
* more verbosity about input values